### PR TITLE
Add name to a task

### DIFF
--- a/templates/others/check_for_configuration_specifications.yml
+++ b/templates/others/check_for_configuration_specifications.yml
@@ -56,6 +56,7 @@ stages:
                   instScript=false
                   echo "##vso[task.setVariable variable=instScript;isOutput=true]$instScript"
               fi
+            name: scripts
 
           # - script: |
 


### PR DESCRIPTION
I believe that the issue described in #2 is caused by a task missing a name.

Without the name, the reference to the variable in the condition in file `/templates/others/manual_configuration.yml`, line 20

```yml
#/templates/others/manual_configuration.yml`, line 20
condition: and(and(not(or(failed(), canceled())), eq(dependencies.${{ parameters.check_for_configuration_specifications_stage_name }}.outputs['installation_script_check.scripts.instScript'], 'true')), contains(variables['Build.SourceBranch'], 'refs/heads/release/'))
```

does not work, since it cannot find the correct `instScript` variable.

This is only based on reading the code - note that I have not tested if this fixes the issue.