### PR TITLE
Add approvers, approval timestamp and URS text to verification report

### DIFF
--- a/templates/scripts/report/render_requirement_content_and_approvers.py
+++ b/templates/scripts/report/render_requirement_content_and_approvers.py
@@ -1,0 +1,228 @@
+import base64
+import glob
+import os
+import sys
+
+import requests
+import yaml
+
+from report_utils import (
+    extract_features,
+    extract_last_modified_commit_hash,
+    render_tags,
+)
+
+
+def get_pull_requests(
+    base_url: str,
+    auth_method: str,
+    access_token: str,
+    branch: str,
+    api_version: str = "7.1",
+) -> list[dict]:
+    """Get all pull requests which have the current branch as target."""
+
+    url = f"{base_url}/pullRequests?searchCriteria.status=completed&api-version={api_version}"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"{auth_method} {access_token}",
+    }
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        pull_requests = response.json().get("value", [])
+        # Remove the origin/ from the branch name
+        branch = branch.replace("origin/", "")
+        # Filter for only the ones into the current (release) branch
+        pull_requests = [
+            pr for pr in pull_requests if pr["targetRefName"] == f"refs/heads/{branch}"
+        ]
+        # TODO: Sort by time? Or maybe just PR ID?
+        return pull_requests
+    else:
+        return []
+
+
+def match_commit_with_pr(
+    base_url: str,
+    auth_method: str,
+    access_token: str,
+    pull_requests: list[dict],
+    commit_id: str,
+    api_version: str = "7.1",
+) -> tuple[str, str] | None:
+    """Find the pull request which contains a given commit id."""
+
+    # Go through PRs
+    for pr in pull_requests:
+        # Get all commits for the PR
+        url = f"{base_url}/pullRequests/{pr['pullRequestId']}/commits?api-version={api_version}"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"{auth_method} {access_token}",
+        }
+        response = requests.get(url, headers=headers)
+        pr_commits = response.json().get("value", [])
+        # If the commit id is in the PR commits, return the PR id and completion date
+        if any(commit["commitId"] == commit_id for commit in pr_commits):
+            # Remove milliseconds
+            completion_date = pr["closedDate"].split(".")[0] + "Z"
+            return (pr["pullRequestId"], completion_date)
+    return None
+
+
+def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str]:
+    """Get the approvers for a given pull request."""
+
+    for pr in pull_requests:
+
+        if pr["pullRequestId"] == pr_id:
+            reviewers = pr["reviewers"]
+            approvers = [
+                reviewer["uniqueName"]
+                for reviewer in reviewers
+                if reviewer["vote"] == 10
+            ]
+            return approvers
+    else:
+        return []
+
+
+def get_approver_roles(approvers: list[str], roles: dict) -> list[str]:
+    """Get the roles of the approvers by matching initials in the roles.yml
+    file.
+    """
+    approvers_with_roles = []
+    for approver in approvers:
+        # Try to get the roles of the approvers
+        if (initials := approver.split("@")[0].lower()) in roles:
+            approvers_with_roles.append(
+                f"{roles[initials]['name']}, {roles[initials]['role']}"
+            )
+        else:
+            approvers_with_roles.append(approver)
+    return approvers_with_roles
+
+
+# TODO: Add exception handling
+def main(argv):
+    # Guard clause, no arguments provided
+    if len(argv) == 0:
+        print("No arguments provided")
+        exit(1)
+    # Guard clause, too few arguments provided
+    if len(argv) < 14:
+        print("Not all required arguments provided")
+        exit(1)
+
+    # 1. Check for the arg pattern:
+    #   python3 get_requirements.py -folder <filepath> -branch <remote branch> -organization <organization> -project <project> -repository <repository> -accesstoken <access token> -roles <roles file>
+    #   e.g.
+    #       argv[0] is '-folder'
+    #       argv[1] is './../features'
+    #       argv[2] is '-branch'
+    #       argv[3] is 'origin/release/service1'
+    #       argv[4] is '-organization'
+    #       argv[5] is 'novonordiskit'
+    #       argv[6] is '-project'
+    #       argv[7] is 'Data Management and Analytics'
+    #       argv[8] is '-repository'
+    #       argv[9] is 'QMS-TEMPLATE'
+    #       argv[10] is '-accesstoken'
+    #       argv[11] is 'USE_ENV_VARIABLE'
+    #       argv[12] is '-roles'
+    #       argv[13] is 'roles.yml'
+    if (
+        len(argv) == 14
+        and argv[0] == "-folder"
+        and argv[2] == "-branch"
+        and argv[4] == "-organization"
+        and argv[6] == "-project"
+        and argv[8] == "-repository"
+        and argv[10] == "-accesstoken"
+        and argv[12] == "-roles"
+    ):
+
+        # Render all feature descriptions
+        # Find all .feature files in the folder and subfolders
+        path = r"%s/**/*.feature" % argv[1]
+        files = glob.glob(path, recursive=True)
+
+        # Get the current branch
+        branch = argv[3]
+        organization = argv[5]
+        project = argv[7]
+        repository = argv[9]
+        access_token = argv[11]
+        role_file = argv[13] if argv[13] != "" else None
+
+        # URL encode the project name
+        project = project.replace(" ", "%20")
+
+        # Use environment variable to read the protected access token
+        # if we are running in Azure DevOps
+        auth_method = "Basic"
+        if access_token == "USE_ENV_VARIABLE":
+            access_token = os.environ["SYSTEM_ACCESSTOKEN"]
+            auth_method = "Bearer"
+        # If auth method is "Basic", we are most likely running
+        # outside Azure DevOps, so we need to encode the
+        # access token as password in a Basic HTTP Auth header format
+        if auth_method == "Basic":
+            # Base64 encode userid:password, which is empty (no user id) and
+            # the access_token value in a string "<user_id>:<access_token>",
+            # e.g. ":12345678".
+            access_token = base64.b64encode(f":{access_token}".encode()).decode()
+
+        # Load role yaml file if provided
+        if role_file:
+            with open(role_file, "r") as file:
+                roles = yaml.safe_load(file)
+
+        # Base URL for Azure DevOps REST API
+        base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
+
+        pull_requests = get_pull_requests(base_url, auth_method, access_token, branch)
+
+        # Render the table header and the table body element
+        print("<figure>")
+
+        for file in files:
+
+            with open(file, mode="r", encoding="utf-8") as file_reader:
+                lines_raw = file_reader.read()
+                lines = lines_raw.split("\n")
+                features = extract_features(lines)
+
+            last_modified_commit_hash = extract_last_modified_commit_hash(file, branch)
+
+            pr_id, completion_date = match_commit_with_pr(
+                base_url,
+                auth_method,
+                access_token,
+                pull_requests,
+                last_modified_commit_hash,
+            )
+            approvers = get_approvers(pr_id, pull_requests)
+
+            if role_file:
+                approvers = get_approver_roles(approvers, roles)
+
+            for feature in features:
+                print(
+                    f"""    <h4>{render_tags(feature.tags)}</h4>
+    <pre>{lines_raw}</pre>
+    <p>Approved at: {completion_date}</p>
+    <p>Approvers:</p>
+    <ul>"""
+                )
+                for approver in approvers:
+                    print(f"        <li>{approver}</li>")
+                print("""    </ul>""")
+        print("</figure>")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/templates/scripts/report/render_requirements.py
+++ b/templates/scripts/report/render_requirements.py
@@ -113,7 +113,6 @@ def get_pull_requests(
         # TODO: Sort by time? Or maybe just PR ID?
         return pull_requests
     else:
-        print(f"Failed to fetch pull requests: {response.status_code}")
         return []
 
 
@@ -145,7 +144,7 @@ def match_commit_with_pr(
     return None
 
 
-def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str] | None:
+def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str]:
     """Get the approvers for a given pull request."""
 
     for pr in pull_requests:
@@ -159,8 +158,7 @@ def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str] | None:
             ]
             return approvers
     else:
-        print("No approvers found")
-        return None
+        return []
 
 
 def get_approver_roles(approvers: list[str], roles: dict) -> list[str]:

--- a/templates/scripts/report/render_requirements.py
+++ b/templates/scripts/report/render_requirements.py
@@ -322,6 +322,8 @@ def main(argv):
                 lines = lines_raw.split("\n")
                 features = extract_features(lines)
 
+            last_modified_commit_hash = extract_last_modified_commit_hash(file, branch)
+
             pr_id, completion_date = match_commit_with_pr(
                 base_url,
                 auth_method,

--- a/templates/scripts/report/render_requirements.py
+++ b/templates/scripts/report/render_requirements.py
@@ -104,6 +104,8 @@ def get_pull_requests(
 
     if response.status_code == 200:
         pull_requests = response.json().get("value", [])
+        # Remove the origin/ from the branch name
+        branch = branch.replace("origin/", "")
         # Filter for only the ones into the current (release) branch
         pull_requests = [
             pr for pr in pull_requests if pr["targetRefName"] == f"refs/heads/{branch}"

--- a/templates/scripts/report/render_requirements.py
+++ b/templates/scripts/report/render_requirements.py
@@ -1,180 +1,13 @@
-import base64
+import sys
 import glob
 import os
-import subprocess
-import sys
 
-import requests
-import yaml
-
-
-# List of tags that are being removed when rendering the list of requirements, leaving only the unique ID(s)
-RESERVED_TAGS = ["URS", "GxP", "non-GxP", "CA"]
-
-
-class Feature:
-    def __init__(self, name, description, tags):
-        self.name = name
-        self.description = description
-        self.tags = tags
-
-
-def extract_features(lines):
-    features = []
-    for i, line in enumerate(lines):
-        if "@URS" in line:
-            fo = Feature(None, description=[], tags=line)
-            for j in range(i + 1, len(lines)):
-                feature_line = lines[j]
-                if "Feature:" in feature_line:
-                    feature_name = feature_line.split("Feature:")[1].strip()
-                    feature_description = lines[j + 1 : j + 5]
-                    fo.name = feature_name
-                    fo.description = [
-                        desc.strip() for desc in feature_description if desc.strip()
-                    ]
-                    features.append(fo)
-                    break
-
-    return features
-
-
-def extract_last_modified_commit_hash(filepath, branch):
-    # git log <remote branch> -n 1 --pretty=format:%H -- <filepath>
-    result = subprocess.run(
-        ["git", "log", branch, "-n", "1", "--pretty=format:%H", "--", filepath],
-        stdout=subprocess.PIPE,
-    )
-    return result.stdout.decode()
-
-
-def extract_last_modified_commit_hash_timestamp(commit_hash):
-    # git show -s --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' <commit_hash>
-    result = subprocess.run(
-        [
-            "git",
-            "show",
-            "-s",
-            "--format=%cd",
-            "--date=format:'%Y-%m-%d %H:%M:%S'",
-            commit_hash,
-        ],
-        stdout=subprocess.PIPE,
-    )
-    return result.stdout.decode()
-
-
-def remove_values_from_string(string, values):
-    for value in values:
-        string = string.replace(value, "")
-    return string
-
-
-def clean_tags(tags) -> list:
-    tags = remove_values_from_string(tags, RESERVED_TAGS)
-    tags = tags.replace("@", "")
-    tags = tags.strip()
-    return tags
-
-
-def render_tags(tags) -> str:
-    tags = clean_tags(tags)
-    tags = tags.split(" ")
-    tags = [f"<kbd>{tag}</kbd>" for tag in tags]
-    return "".join(tags)
-
-
-def get_pull_requests(
-    base_url: str,
-    auth_method: str,
-    access_token: str,
-    branch: str,
-    api_version: str = "7.1",
-) -> list[dict]:
-    """Get all pull requests which have the current branch as target."""
-
-    url = f"{base_url}/pullRequests?searchCriteria.status=completed&api-version={api_version}"
-
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"{auth_method} {access_token}",
-    }
-
-    response = requests.get(url, headers=headers)
-
-    if response.status_code == 200:
-        pull_requests = response.json().get("value", [])
-        # Remove the origin/ from the branch name
-        branch = branch.replace("origin/", "")
-        # Filter for only the ones into the current (release) branch
-        pull_requests = [
-            pr for pr in pull_requests if pr["targetRefName"] == f"refs/heads/{branch}"
-        ]
-        # TODO: Sort by time? Or maybe just PR ID?
-        return pull_requests
-    else:
-        return []
-
-
-def match_commit_with_pr(
-    base_url: str,
-    auth_method: str,
-    access_token: str,
-    pull_requests: list[dict],
-    commit_id: str,
-    api_version: str = "7.1",
-) -> tuple[str, str] | None:
-    """Find the pull request which contains a given commit id."""
-
-    # Go through PRs
-    for pr in pull_requests:
-        # Get all commits for the PR
-        url = f"{base_url}/pullRequests/{pr['pullRequestId']}/commits?api-version={api_version}"
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"{auth_method} {access_token}",
-        }
-        response = requests.get(url, headers=headers)
-        pr_commits = response.json().get("value", [])
-        # If the commit id is in the PR commits, return the PR id and completion date
-        if any(commit["commitId"] == commit_id for commit in pr_commits):
-            # Remove milliseconds
-            completion_date = pr["closedDate"].split(".")[0] + "Z"
-            return (pr["pullRequestId"], completion_date)
-    return None
-
-
-def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str]:
-    """Get the approvers for a given pull request."""
-
-    for pr in pull_requests:
-
-        if pr["pullRequestId"] == pr_id:
-            reviewers = pr["reviewers"]
-            approvers = [
-                reviewer["uniqueName"]
-                for reviewer in reviewers
-                if reviewer["vote"] == 10
-            ]
-            return approvers
-    else:
-        return []
-
-
-def get_approver_roles(approvers: list[str], roles: dict) -> list[str]:
-    """Get the roles of the approvers by matching initials in the roles.yml
-    file.
-    """
-    approvers_with_roles = []
-    for approver in approvers:
-        # Try to get the roles of the approvers
-        if (initials := approver.split("@")[0].lower()) in roles:
-            approvers_with_roles.append(
-                f"{roles[initials]['name']}, {roles[initials]['role']}"
-            )
-        else:
-            approvers_with_roles.append(approver)
-    return approvers_with_roles
+from report_utils import (
+    extract_features,
+    extract_last_modified_commit_hash,
+    extract_last_modified_commit_hash_timestamp,
+    render_tags,
+)
 
 
 # TODO: Add exception handling
@@ -184,12 +17,12 @@ def main(argv):
         print("No arguments provided")
         exit(1)
     # Guard clause, too few arguments provided
-    if len(argv) < 14:
+    if len(argv) < 10:
         print("Not all required arguments provided")
         exit(1)
 
     # 1. Check for the arg pattern:
-    #   python3 get_requirements.py -folder <filepath> -branch <remote branch> -organization <organization> -project <project> -repository <repository> -accesstoken <access token> -roles <roles file>
+    #   python3 get_requirements.py -folder <filepath> -branch <remote branch> -organization <organization> -project <project> -repository <repository>
     #   e.g.
     #       argv[0] is '-folder'
     #       argv[1] is './../features'
@@ -201,19 +34,13 @@ def main(argv):
     #       argv[7] is 'Data Management and Analytics'
     #       argv[8] is '-repository'
     #       argv[9] is 'QMS-TEMPLATE'
-    #       argv[10] is '-accesstoken'
-    #       argv[11] is 'USE_ENV_VARIABLE'
-    #       argv[12] is '-roles'
-    #       argv[13] is 'roles.yml'
     if (
-        len(argv) == 14
+        len(argv) == 10
         and argv[0] == "-folder"
         and argv[2] == "-branch"
         and argv[4] == "-organization"
         and argv[6] == "-project"
         and argv[8] == "-repository"
-        and argv[10] == "-accesstoken"
-        and argv[12] == "-roles"
     ):
 
         # Render all feature descriptions
@@ -226,26 +53,9 @@ def main(argv):
         organization = argv[5]
         project = argv[7]
         repository = argv[9]
-        access_token = argv[11]
-        role_file = argv[13] if argv[13] != "" else None
 
         # URL encode the project name
         project = project.replace(" ", "%20")
-
-        # Use environment variable to read the protected access token
-        # if we are running in Azure DevOps
-        auth_method = "Basic"
-        if access_token == "USE_ENV_VARIABLE":
-            access_token = os.environ["SYSTEM_ACCESSTOKEN"]
-            auth_method = "Bearer"
-        # If auth method is "Basic", we are most likely running
-        # outside Azure DevOps, so we need to encode the
-        # access token as password in a Basic HTTP Auth header format
-        if auth_method == "Basic":
-            # Base64 encode userid:password, which is empty (no user id) and
-            # the access_token value in a string "<user_id>:<access_token>",
-            # e.g. ":12345678".
-            access_token = base64.b64encode(f":{access_token}".encode()).decode()
 
         # Render the table header and the table body element
         print(
@@ -264,7 +74,6 @@ def main(argv):
         <tbody>"""
         )
 
-        # Part 1: Get table with requirement details
         count_features = 0
         for file in files:
             last_modified_commit_hash = extract_last_modified_commit_hash(file, branch)
@@ -300,54 +109,9 @@ def main(argv):
         # Render the table body close elements
         print(
             """        </tbody>
-    </table>"""
+    </table>
+</figure>"""
         )
-
-        # Part 2: Print feature files with approvers
-
-        # Load role yaml file if provided
-        if role_file:
-            with open(role_file, "r") as file:
-                roles = yaml.safe_load(file)
-
-        # Base URL for Azure DevOps REST API
-        base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
-
-        pull_requests = get_pull_requests(base_url, auth_method, access_token, branch)
-
-        for file in files:
-
-            with open(file, mode="r", encoding="utf-8") as file_reader:
-                lines_raw = file_reader.read()
-                lines = lines_raw.split("\n")
-                features = extract_features(lines)
-
-            last_modified_commit_hash = extract_last_modified_commit_hash(file, branch)
-
-            pr_id, completion_date = match_commit_with_pr(
-                base_url,
-                auth_method,
-                access_token,
-                pull_requests,
-                last_modified_commit_hash,
-            )
-            approvers = get_approvers(pr_id, pull_requests)
-
-            if role_file:
-                approvers = get_approver_roles(approvers, roles)
-
-            for feature in features:
-                print(
-                    f"""    <h4>{render_tags(feature.tags)}</h4>
-    <pre>{lines_raw}</pre>
-    <p>Approved at: {completion_date}</p>
-    <p>Approvers:</p>
-    <ul>"""
-                )
-                for approver in approvers:
-                    print(f"        <li>{approver}</li>")
-                print("""    </ul>""")
-        print("</figure>")
 
 
 if __name__ == "__main__":

--- a/templates/scripts/report/render_requirements.py
+++ b/templates/scripts/report/render_requirements.py
@@ -1,59 +1,181 @@
-import sys
+import base64
 import glob
 import os
 import subprocess
+import sys
+
+import requests
+import yaml
+
 
 # List of tags that are being removed when rendering the list of requirements, leaving only the unique ID(s)
 RESERVED_TAGS = ["URS", "GxP", "non-GxP", "CA"]
+
+
 class Feature:
     def __init__(self, name, description, tags):
         self.name = name
         self.description = description
         self.tags = tags
 
+
 def extract_features(lines):
     features = []
     for i, line in enumerate(lines):
-        if '@URS' in line:
+        if "@URS" in line:
             fo = Feature(None, description=[], tags=line)
             for j in range(i + 1, len(lines)):
                 feature_line = lines[j]
-                if 'Feature:' in feature_line:
-                    feature_name = feature_line.split('Feature:')[1].strip()
-                    feature_description = lines[j + 1:j + 5]
+                if "Feature:" in feature_line:
+                    feature_name = feature_line.split("Feature:")[1].strip()
+                    feature_description = lines[j + 1 : j + 5]
                     fo.name = feature_name
-                    fo.description = [desc.strip() for desc in feature_description if desc.strip()]
+                    fo.description = [
+                        desc.strip() for desc in feature_description if desc.strip()
+                    ]
                     features.append(fo)
                     break
 
     return features
 
+
 def extract_last_modified_commit_hash(filepath, branch):
     # git log <remote branch> -n 1 --pretty=format:%H -- <filepath>
-    result = subprocess.run(['git', 'log', branch, '-n', '1', '--pretty=format:%H', '--', filepath], stdout=subprocess.PIPE)
+    result = subprocess.run(
+        ["git", "log", branch, "-n", "1", "--pretty=format:%H", "--", filepath],
+        stdout=subprocess.PIPE,
+    )
     return result.stdout.decode()
+
 
 def extract_last_modified_commit_hash_timestamp(commit_hash):
     # git show -s --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' <commit_hash>
-    result = subprocess.run(['git', 'show', '-s', '--format=%cd', "--date=format:'%Y-%m-%d %H:%M:%S'", commit_hash], stdout=subprocess.PIPE)
+    result = subprocess.run(
+        [
+            "git",
+            "show",
+            "-s",
+            "--format=%cd",
+            "--date=format:'%Y-%m-%d %H:%M:%S'",
+            commit_hash,
+        ],
+        stdout=subprocess.PIPE,
+    )
     return result.stdout.decode()
+
 
 def remove_values_from_string(string, values):
     for value in values:
-        string = string.replace(value, '')
+        string = string.replace(value, "")
     return string
+
 
 def clean_tags(tags) -> list:
     tags = remove_values_from_string(tags, RESERVED_TAGS)
-    tags = tags.replace('@', '')
+    tags = tags.replace("@", "")
     tags = tags.strip()
     return tags
 
+
 def render_tags(tags) -> str:
     tags = clean_tags(tags)
-    tags = tags.split(' ')
-    tags = [f'<kbd>{tag}</kbd>' for tag in tags]
-    return ''.join(tags)
+    tags = tags.split(" ")
+    tags = [f"<kbd>{tag}</kbd>" for tag in tags]
+    return "".join(tags)
+
+
+def get_pull_requests(
+    base_url: str,
+    auth_method: str,
+    access_token: str,
+    branch: str,
+    api_version: str = "7.1",
+) -> list[dict]:
+    """Get all pull requests which have the current branch as target."""
+
+    url = f"{base_url}/pullRequests?searchCriteria.status=completed&api-version={api_version}"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"{auth_method} {access_token}",
+    }
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        pull_requests = response.json().get("value", [])
+        # Filter for only the ones into the current (release) branch
+        pull_requests = [
+            pr for pr in pull_requests if pr["targetRefName"] == f"refs/heads/{branch}"
+        ]
+        # TODO: Sort by time? Or maybe just PR ID?
+        return pull_requests
+    else:
+        print(f"Failed to fetch pull requests: {response.status_code}")
+        return []
+
+
+def match_commit_with_pr(
+    base_url: str,
+    auth_method: str,
+    access_token: str,
+    pull_requests: list[dict],
+    commit_id: str,
+    api_version: str = "7.1",
+) -> tuple[str, str] | None:
+    """Find the pull request which contains a given commit id."""
+
+    # Go through PRs
+    for pr in pull_requests:
+        # Get all commits for the PR
+        url = f"{base_url}/pullRequests/{pr['pullRequestId']}/commits?api-version={api_version}"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"{auth_method} {access_token}",
+        }
+        response = requests.get(url, headers=headers)
+        pr_commits = response.json().get("value", [])
+        # If the commit id is in the PR commits, return the PR id and completion date
+        if any(commit["commitId"] == commit_id for commit in pr_commits):
+            # Remove milliseconds
+            completion_date = pr["closedDate"].split(".")[0] + "Z"
+            return (pr["pullRequestId"], completion_date)
+    return None
+
+
+def get_approvers(pr_id: str, pull_requests: list[dict]) -> list[str] | None:
+    """Get the approvers for a given pull request."""
+
+    for pr in pull_requests:
+
+        if pr["pullRequestId"] == pr_id:
+            reviewers = pr["reviewers"]
+            approvers = [
+                reviewer["uniqueName"]
+                for reviewer in reviewers
+                if reviewer["vote"] == 10
+            ]
+            return approvers
+    else:
+        print("No approvers found")
+        return None
+
+
+def get_approver_roles(approvers: list[str], roles: dict) -> list[str]:
+    """Get the roles of the approvers by matching initials in the roles.yml
+    file.
+    """
+    approvers_with_roles = []
+    for approver in approvers:
+        # Try to get the roles of the approvers
+        if (initials := approver.split("@")[0].lower()) in roles:
+            approvers_with_roles.append(
+                f"{roles[initials]['name']}, {roles[initials]['role']}"
+            )
+        else:
+            approvers_with_roles.append(approver)
+    return approvers_with_roles
+
 
 # TODO: Add exception handling
 def main(argv):
@@ -62,13 +184,13 @@ def main(argv):
         print("No arguments provided")
         exit(1)
     # Guard clause, too few arguments provided
-    if len(argv) < 10:
+    if len(argv) < 14:
         print("Not all required arguments provided")
         exit(1)
 
     # 1. Check for the arg pattern:
-    #   python3 get_requirements.py -folder <filepath> -branch <remote branch> -organization <organization> -project <project> -repository <repository>
-    #   e.g. 
+    #   python3 get_requirements.py -folder <filepath> -branch <remote branch> -organization <organization> -project <project> -repository <repository> -accesstoken <access token> -roles <roles file>
+    #   e.g.
     #       argv[0] is '-folder'
     #       argv[1] is './../features'
     #       argv[2] is '-branch'
@@ -79,11 +201,24 @@ def main(argv):
     #       argv[7] is 'Data Management and Analytics'
     #       argv[8] is '-repository'
     #       argv[9] is 'QMS-TEMPLATE'
-    if len(argv) == 10 and argv[0] == '-folder' and argv[2] == '-branch' and argv[4] == '-organization' and argv[6] == '-project' and argv[8] == '-repository':
-	
+    #       argv[10] is '-accesstoken'
+    #       argv[11] is 'USE_ENV_VARIABLE'
+    #       argv[12] is '-roles'
+    #       argv[13] is 'roles.yml'
+    if (
+        len(argv) == 14
+        and argv[0] == "-folder"
+        and argv[2] == "-branch"
+        and argv[4] == "-organization"
+        and argv[6] == "-project"
+        and argv[8] == "-repository"
+        and argv[10] == "-accesstoken"
+        and argv[12] == "-roles"
+    ):
+
         # Render all feature descriptions
         # Find all .feature files in the folder and subfolders
-        path = r'%s/**/*.feature' % argv[1]
+        path = r"%s/**/*.feature" % argv[1]
         files = glob.glob(path, recursive=True)
 
         # Get the current branch
@@ -91,12 +226,30 @@ def main(argv):
         organization = argv[5]
         project = argv[7]
         repository = argv[9]
+        access_token = argv[11]
+        role_file = argv[13] if argv[13] != "" else None
 
         # URL encode the project name
         project = project.replace(" ", "%20")
-        
+
+        # Use environment variable to read the protected access token
+        # if we are running in Azure DevOps
+        auth_method = "Basic"
+        if access_token == "USE_ENV_VARIABLE":
+            access_token = os.environ["SYSTEM_ACCESSTOKEN"]
+            auth_method = "Bearer"
+        # If auth method is "Basic", we are most likely running
+        # outside Azure DevOps, so we need to encode the
+        # access token as password in a Basic HTTP Auth header format
+        if auth_method == "Basic":
+            # Base64 encode userid:password, which is empty (no user id) and
+            # the access_token value in a string "<user_id>:<access_token>",
+            # e.g. ":12345678".
+            access_token = base64.b64encode(f":{access_token}".encode()).decode()
+
         # Render the table header and the table body element
-        print('''<figure>
+        print(
+            """<figure>
     <table>
         <thead>
             <tr>
@@ -108,38 +261,92 @@ def main(argv):
                 <th scope="col">File</th>
             </tr>
         </thead>
-        <tbody>''')
+        <tbody>"""
+        )
 
+        # Part 1: Get table with requirement details
         count_features = 0
         for file in files:
             last_modified_commit_hash = extract_last_modified_commit_hash(file, branch)
-            last_modified_commit_hash_timestamp = extract_last_modified_commit_hash_timestamp(last_modified_commit_hash).strip().replace("'", "")
+            last_modified_commit_hash_timestamp = (
+                extract_last_modified_commit_hash_timestamp(last_modified_commit_hash)
+                .strip()
+                .replace("'", "")
+            )
 
-            with open(file, mode='r', encoding='utf-8') as file_reader:
-                lines = file_reader.read().split('\n')
+            with open(file, mode="r", encoding="utf-8") as file_reader:
+                lines = file_reader.read().split("\n")
                 features = extract_features(lines)
                 # Extract the path to the feature file, e.g.:
                 # /requirements/features/urs/functionality1.feature
                 repository_file_path = os.path.abspath(file).replace(os.getcwd(), "")
                 # Create link to path for file, e.g.:
                 # https://dev.azure.com/novonordiskit/Data%20Management%20and%20Analytics/_git/QMS-TEMPLATE/commit/d78d1bf6bd41b07f654c6b8178fb85b4490853f3?path=/requirements/features/urs/reverse-string-feat.feature
-                repository_file_link = f'https://dev.azure.com/{organization}/{project}/_git/{repository}/commit/{last_modified_commit_hash}?path={repository_file_path}'
+                repository_file_link = f"https://dev.azure.com/{organization}/{project}/_git/{repository}/commit/{last_modified_commit_hash}?path={repository_file_path}"
 
                 for feature in features:
                     count_features += 1
-                    print(f'''            <tr>
+                    print(
+                        f"""            <tr>
                 <th scope="row">{count_features}</th>
                 <td>{render_tags(feature.tags)}</td>
                 <td>{feature.name}</td>
                 <td>{last_modified_commit_hash}</td>
                 <td>{last_modified_commit_hash_timestamp}</td>
                 <td><a href="{repository_file_link}" target="_blank">{repository_file_path}</a></td>
-            </tr>''')
+            </tr>"""
+                    )
 
         # Render the table body close elements
-        print('''        </tbody>
-    </table>
-</figure>''')
+        print(
+            """        </tbody>
+    </table>"""
+        )
+
+        # Part 2: Print feature files with approvers
+
+        # Load role yaml file if provided
+        if role_file:
+            with open(role_file, "r") as file:
+                roles = yaml.safe_load(file)
+
+        # Base URL for Azure DevOps REST API
+        base_url = f"https://dev.azure.com/{organization}/{project}/_apis/git/repositories/{repository}"
+
+        pull_requests = get_pull_requests(base_url, auth_method, access_token, branch)
+
+        for file in files:
+
+            with open(file, mode="r", encoding="utf-8") as file_reader:
+                lines_raw = file_reader.read()
+                lines = lines_raw.split("\n")
+                features = extract_features(lines)
+
+            pr_id, completion_date = match_commit_with_pr(
+                base_url,
+                auth_method,
+                access_token,
+                pull_requests,
+                last_modified_commit_hash,
+            )
+            approvers = get_approvers(pr_id, pull_requests)
+
+            if role_file:
+                approvers = get_approver_roles(approvers, roles)
+
+            for feature in features:
+                print(
+                    f"""    <h4>{render_tags(feature.tags)}</h4>
+    <pre>{lines_raw}</pre>
+    <p>Approved at: {completion_date}</p>
+    <p>Approvers:</p>
+    <ul>"""
+                )
+                for approver in approvers:
+                    print(f"        <li>{approver}</li>")
+                print("""    </ul>""")
+        print("</figure>")
+
 
 if __name__ == "__main__":
-   main(sys.argv[1:])
+    main(sys.argv[1:])

--- a/templates/scripts/report/report_utils.py
+++ b/templates/scripts/report/report_utils.py
@@ -1,0 +1,76 @@
+import subprocess
+
+# List of tags that are being removed when rendering the list of requirements, leaving only the unique ID(s)
+RESERVED_TAGS = ["URS", "GxP", "non-GxP", "CA"]
+
+
+class Feature:
+    def __init__(self, name, description, tags):
+        self.name = name
+        self.description = description
+        self.tags = tags
+
+
+def extract_features(lines):
+    features = []
+    for i, line in enumerate(lines):
+        if "@URS" in line:
+            fo = Feature(None, description=[], tags=line)
+            for j in range(i + 1, len(lines)):
+                feature_line = lines[j]
+                if "Feature:" in feature_line:
+                    feature_name = feature_line.split("Feature:")[1].strip()
+                    feature_description = lines[j + 1 : j + 5]
+                    fo.name = feature_name
+                    fo.description = [
+                        desc.strip() for desc in feature_description if desc.strip()
+                    ]
+                    features.append(fo)
+                    break
+
+    return features
+
+
+def extract_last_modified_commit_hash(filepath, branch):
+    # git log <remote branch> -n 1 --pretty=format:%H -- <filepath>
+    result = subprocess.run(
+        ["git", "log", branch, "-n", "1", "--pretty=format:%H", "--", filepath],
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout.decode()
+
+
+def extract_last_modified_commit_hash_timestamp(commit_hash):
+    # git show -s --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' <commit_hash>
+    result = subprocess.run(
+        [
+            "git",
+            "show",
+            "-s",
+            "--format=%cd",
+            "--date=format:'%Y-%m-%d %H:%M:%S'",
+            commit_hash,
+        ],
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout.decode()
+
+
+def remove_values_from_string(string, values):
+    for value in values:
+        string = string.replace(value, "")
+    return string
+
+
+def clean_tags(tags) -> list:
+    tags = remove_values_from_string(tags, RESERVED_TAGS)
+    tags = tags.replace("@", "")
+    tags = tags.strip()
+    return tags
+
+
+def render_tags(tags) -> str:
+    tags = clean_tags(tags)
+    tags = tags.split(" ")
+    tags = [f"<kbd>{tag}</kbd>" for tag in tags]
+    return "".join(tags)

--- a/templates/templates/report/VerificationReportTemplate.html
+++ b/templates/templates/report/VerificationReportTemplate.html
@@ -177,6 +177,7 @@
                 <!-- COMMENT: Again, we would need to get this after the merge of the main->release branch PR, which means we need to be able to find that specific PR -->
                 <!-- list all enabled URS -->
                 <p><var>LIST_OF_REQUIREMENTS</var></p>
+                <p><var>REQUIREMENT_CONTENTS_AND_APPROVERS</var></p>
             </article>
         
             <!-- list markdown files in the dedicated design folder at the time of pull request completion -->

--- a/templates/verify/generate_verification_report.yml
+++ b/templates/verify/generate_verification_report.yml
@@ -13,6 +13,7 @@ parameters:
   render_json_test_result_py_location: "qms-pipeline-templates/templates/scripts/report/render_json_test_result.py"
   render_replace_py_location: "qms-pipeline-templates/templates/scripts/report/render_replace.py"
   render_requirements_py_location: "qms-pipeline-templates/templates/scripts/report/render_requirements.py"
+  render_requirement_content_and_approvers_py_location: "qms-pipeline-templates/templates/scripts/report/render_requirement_content_and_approvers.py"
   get_pull_request_id_py_location: "qms-pipeline-templates/templates/scripts/report/get_pull_request_id.py"
   extract_requirements_name_to_id_mapping_py_location: "qms-pipeline-templates/templates/scripts/report/extract_requirements_name_to_id_mapping.py"
   get_verification_report_filename_for_context_sh_location: "qms-pipeline-templates/templates/scripts/report/get_verification_report_filename_for_context.sh"
@@ -140,8 +141,12 @@ stages:
               python3 ../${{ parameters.extract_requirements_name_to_id_mapping_py_location }} -folder ${{ parameters.feature_files_path }} > ../requirementsNameToIdMapping.dict
 
               echo -e "================> ${PURPLE}Extracting and rendering requirements${NC}"
-              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) -accesstoken USE_ENV_VARIABLE -roles '${{ parameters.roles_file_path}}' > listOfRequirementsHtml.html
+              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) > listOfRequirementsHtml.html
               python3 ../${{ parameters.render_replace_py_location }} -render ./listOfRequirementsHtml.html -template ../${{ parameters.verification_report_template_location }} -placeholder "<var>LIST_OF_REQUIREMENTS</var>"
+
+              echo -e "================> ${PURPLE}Extracting and rendering requirement contents with approvers${NC}"
+              python3 ../${{ parameters.render_requirement_content_and_approvers_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) -accesstoken USE_ENV_VARIABLE -roles '${{ parameters.roles_file_path}}' > requirementContentsAndApproversHtml.html
+              python3 ../${{ parameters.render_replace_py_location }} -render ./requirementContentsAndApproversHtml.html -template ../${{ parameters.verification_report_template_location }} -placeholder "<var>REQUIREMENT_CONTENTS_AND_APPROVERS</var>"
 
               echo -e "================> ${PURPLE}Extracting and rendering design specifications${NC}"
               python3 ../${{ parameters.render_design_specifications_py_location }} -folder ${{ parameters.system_design_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) > listOfDesignSpecifications.html

--- a/templates/verify/generate_verification_report.yml
+++ b/templates/verify/generate_verification_report.yml
@@ -76,6 +76,7 @@ stages:
               echo -e "${PURPLE}environment_name:${NC} ${{ parameters.environment_name }}"
               echo -e "${PURPLE}it_solution_name:${NC} ${{ parameters.it_solution_name }}"
               echo -e "${PURPLE}feature_files_path:${NC} ${{ parameters.feature_files_path }}"
+              echo -e "${PURPLE}roles_file_path:${NC} ${{ parameters.roles_file_path }}"
               echo -e "${PURPLE}system_design_path:${NC} ${{ parameters.system_design_path }}"
               echo -e "${PURPLE}system_configuration_path:${NC} ${{ parameters.system_configuration_path }}"
               echo -e "${PURPLE}verification_report_template_location:${NC} ${{ parameters.verification_report_template_location }}"

--- a/templates/verify/generate_verification_report.yml
+++ b/templates/verify/generate_verification_report.yml
@@ -3,6 +3,7 @@ parameters:
   environment_name: ""
   it_solution_name: ""
   feature_files_path: ""
+  roles_file_path: ""
   system_design_path: ""
   system_configuration_path: ""
   template_repo: "qms_pipeline_templates"
@@ -43,7 +44,7 @@ stages:
         strategy:
           matrix:
             Python310:
-              python.version: '3.10'
+              python.version: "3.10"
         workspace:
           clean: all
         steps:
@@ -64,7 +65,7 @@ stages:
 
           - script: |
               python3 -m ensurepip --upgrade
-              pip3 install requests
+              pip3 install pyyaml requests
               RED='\033[0;31m'    # Red
               GREEN='\033[0;32m'  # Green
               PURPLE='\033[0;35m' # Purple
@@ -138,7 +139,7 @@ stages:
               python3 ../${{ parameters.extract_requirements_name_to_id_mapping_py_location }} -folder ${{ parameters.feature_files_path }} > ../requirementsNameToIdMapping.dict
 
               echo -e "================> ${PURPLE}Extracting and rendering requirements${NC}"
-              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) > listOfRequirementsHtml.html
+              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) -accesstoken USE_ENV_VARIABLE -roles ${{ parameters.roles_file_path}} > listOfRequirementsHtml.html
               python3 ../${{ parameters.render_replace_py_location }} -render ./listOfRequirementsHtml.html -template ../${{ parameters.verification_report_template_location }} -placeholder "<var>LIST_OF_REQUIREMENTS</var>"
 
               echo -e "================> ${PURPLE}Extracting and rendering design specifications${NC}"
@@ -199,5 +200,3 @@ stages:
           - publish: $(verification_report_file)
             artifact: $(verification_report_artifact)
             displayName: Publish verification report as build artifact
-
-          

--- a/templates/verify/generate_verification_report.yml
+++ b/templates/verify/generate_verification_report.yml
@@ -140,7 +140,7 @@ stages:
               python3 ../${{ parameters.extract_requirements_name_to_id_mapping_py_location }} -folder ${{ parameters.feature_files_path }} > ../requirementsNameToIdMapping.dict
 
               echo -e "================> ${PURPLE}Extracting and rendering requirements${NC}"
-              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) -accesstoken USE_ENV_VARIABLE -roles ${{ parameters.roles_file_path}} > listOfRequirementsHtml.html
+              python3 ../${{ parameters.render_requirements_py_location }} -folder ${{ parameters.feature_files_path }} -branch origin/release/$(Build.SourceBranchName) -organization novonordiskit -project '$(System.TeamProject)' -repository $(Build.Repository.Name) -accesstoken USE_ENV_VARIABLE -roles '${{ parameters.roles_file_path}}' > listOfRequirementsHtml.html
               python3 ../${{ parameters.render_replace_py_location }} -render ./listOfRequirementsHtml.html -template ../${{ parameters.verification_report_template_location }} -placeholder "<var>LIST_OF_REQUIREMENTS</var>"
 
               echo -e "================> ${PURPLE}Extracting and rendering design specifications${NC}"


### PR DESCRIPTION
Main:
- Changed `render_requirements.py` to add a second part in the Requirements section of the verification report to include:
    - Approvers of the PR the feature file was changed
    - Approval timestamp of PR where feature was changed
    - Current text of the feature file
- This change improves audit readiness drastically
- Added option of providing a roles file (.yml) in to allow for a mapping of novo initials to actual names and roles in the project  

Outcome:
<img width="1698" alt="new-section" src="https://github.com/user-attachments/assets/15bdebea-b254-4c39-a631-e65b2eb0ff34" />

Without providing optional roles.yml:
<img width="702" alt="no-roles-file" src="https://github.com/user-attachments/assets/72a3039e-e1d0-4f75-a5ec-20a4f8e2b8e6" />

Also works if no one approved PR (though I'm wondering if it even should):
<img width="623" alt="no-approver" src="https://github.com/user-attachments/assets/93a2819c-05e4-4189-b73c-1bdca0723982" />

